### PR TITLE
ヘッダーのレスポンシブ対応

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,60 +11,59 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-dark sticky-top bg-dark py-0">
+    <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
       <%= image_tag 'Crystal.png' %>
-      <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed " data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-      </div>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
 
-      <ul id="navbar" class="navbar-collapse collapse" style="list-style: none;" align="right">
-        <li><a class="nav-link" href="/">ホーム</a></li>
-        <li><a class="nav-link" href=<%= searches_path %>>生年月日入力</a></li>
-        <li><a class="nav-link" href="/favorite">お気に入り</a></li>
-      
-        <li><a href="" class="nav-link" data-toggle="modal" data-target="#aboutModal" >このサイトについて</a></li>
-          <div class="modal fade" id="aboutModal" data-backdrop="false">
-            <div class="modal-dialog">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h4 class="modal-title">ようこそ！</h4>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                </div>
-                <div class="modal-body" align="left">
-                  この診断ではあなたの生年月日から、</br>
-                  気になる誰かの生年月日から！</br>
-                  性格、言われて嬉しい言葉、嫌な言葉を占います！</br>
-                  また、診断結果はお気に入りに保存できますので忘れてしまう心配も無用！</br></br>
-                  <ul>
-                    <li>ホーム：ホーム画面に飛びます。</li>
-                    <li>生年月日入力：生年月日から占いができます。</li>
-                    <li>お気に入り：お気に入り保存した占いを閲覧できます。</li>
-                    <li>このサイトについて：今押したボタン、操作説明。</li>
-                    <li>ログアウト：ログアウトをしてログイン画面に飛びます。</li>
-                  <ul>
-                </div>
-                <div class="modal-footer">
-                  <button type="button" class="btn btn-primary" data-dismiss="modal">閉じる</button>
+      <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+        <ul class="navbar-nav mr-auto">
+          <li class="nav-item active">
+            <a class="nav-link" href="/">ホーム</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href=<%= searches_path %>>生年月日入力</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/favorite">お気に入り</a>
+          </li>
+          <li class="nav-item">
+            <a href="" class="nav-link" data-toggle="modal" data-target="#aboutModal" >このサイトについて</a></li>
+            <div class="modal fade" id="aboutModal" data-backdrop="false">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h4 class="modal-title">ようこそ！</h4>
+                      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                  </div>
+                  <div class="modal-body" align="left">
+                    この診断ではあなたの生年月日から、</br>
+                    気になる誰かの生年月日から！</br>
+                    性格、言われて嬉しい言葉、嫌な言葉を占います！</br>
+                    また、診断結果はお気に入りに保存できますので忘れてしまう心配も無用！</br></br>
+                    <ul>
+                      <li>ホーム：ホーム画面に飛びます。</li>
+                      <li>生年月日入力：生年月日から占いができます。</li>
+                      <li>お気に入り：お気に入り保存した占いを閲覧できます。</li>
+                      <li>このサイトについて：今押したボタン、操作説明。</li>
+                      <li>ログアウト：ログアウトをしてログイン画面に飛びます。</li>
+                    <ul>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">閉じる</button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-    
-        <li>
-          <ul class="navbar-nav px-3">
-            <li class="nav-item text-nowrap">
-              <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'navbar-link'  %> 
-            </li>
-          </ul>
-        </li>
-      </ul>
+          <li>
+          <li class="nav-item">
+            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'nav-link'  %>
+          </li>
+        </ul>
+      </div>
     </nav>
-  </div>
-    
+
     <div class="container-fluid">
       <div class="row">
         <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    
     <title>BirthdayKarte</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -11,24 +13,25 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+    <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark ">
       <%= image_tag 'Crystal.png' %>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler collapsed" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-
-      <div class="collapse navbar-collapse" id="navbarsExampleDefault">
-        <ul class="navbar-nav mr-auto">
+      
+      <div class="collapse navbar-collapse mx-auto" id="navbarsExampleDefault">
+        <ul class="navbar-nav " align="right">
           <li class="nav-item active">
             <a class="nav-link" href="/">ホーム</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-items active">
             <a class="nav-link" href=<%= searches_path %>>生年月日入力</a>
           </li>
-          <li class="nav-item">
+          <li class="nav-item active">
             <a class="nav-link" href="/favorite">お気に入り</a>
           </li>
-          <li class="nav-item">
+      
+          <li class="nav-item active">
             <a href="" class="nav-link" data-toggle="modal" data-target="#aboutModal" >このサイトについて</a></li>
             <div class="modal fade" id="aboutModal" data-backdrop="false">
               <div class="modal-dialog">
@@ -56,14 +59,15 @@
                 </div>
               </div>
             </div>
-          <li>
-          <li class="nav-item">
-            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'nav-link'  %>
+    
+          <li class="nav-item active">
+            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'nav-link'  %> 
           </li>
         </ul>
       </div>
     </nav>
-
+  </div>
+    
     <div class="container-fluid">
       <div class="row">
         <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,8 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       
-      <div class="collapse navbar-collapse mx-auto" id="navbarsExampleDefault">
-        <ul class="navbar-nav " align="right">
+      <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+        <ul class="navbar-nav  mx-auto" align="right">
           <li class="nav-item active">
             <a class="nav-link" href="/">ホーム</a>
           </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,49 +11,60 @@
   </head>
 
   <body>
-    <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap py-0">
+    <nav class="navbar navbar-dark sticky-top bg-dark py-0">
       <%= image_tag 'Crystal.png' %>
-
-      <a class="nav-link" href="/">ホーム</a>
-      <a class="nav-link" href=<%= searches_path %>>生年月日入力</a>
-      <a class="nav-link" href="/favorite">お気に入り</a>
-
-  <a href="" class="nav-link btn" data-toggle="modal" data-target="#aboutModal" >このサイトについて</a>
-  <div class="modal fade" id="aboutModal" data-backdrop="false">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title">ようこそ！</h4>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body" align="left">
-          この診断ではあなたの生年月日から、</br>
-          気になる誰かの生年月日から！</br>
-          性格、言われて嬉しい言葉、嫌な言葉を占います！</br>
-          また、診断結果はお気に入りに保存できますので忘れてしまう心配も無用！</br></br>
-          
-          <ul>
-            <li>ホーム：ホーム画面に飛びます。</li>
-            <li>生年月日入力：生年月日から占いができます。</li>
-            <li>お気に入り：お気に入り保存した占いを閲覧できます。</li>
-            <li>このサイトについて：今押したボタン、操作説明。</li>
-            <li>ログアウト：ログアウトをしてログイン画面に飛びます。</li>
-          <ul>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-primary" data-dismiss="modal">閉じる</button>
-        </div>
+      <div class="navbar-header">
+        <button type="button" class="navbar-toggle collapsed " data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+          <span class="icon-bar"></span>
+        </button>
       </div>
-    </div>
-  </div>
 
-      <ul class="navbar-nav px-3">
-        <li class="nav-item text-nowrap">
-          <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'navbar-link'  %> 
+      <ul id="navbar" class="navbar-collapse collapse" style="list-style: none;" align="right">
+        <li><a class="nav-link" href="/">ホーム</a></li>
+        <li><a class="nav-link" href=<%= searches_path %>>生年月日入力</a></li>
+        <li><a class="nav-link" href="/favorite">お気に入り</a></li>
+      
+        <li><a href="" class="nav-link" data-toggle="modal" data-target="#aboutModal" >このサイトについて</a></li>
+          <div class="modal fade" id="aboutModal" data-backdrop="false">
+            <div class="modal-dialog">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h4 class="modal-title">ようこそ！</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                </div>
+                <div class="modal-body" align="left">
+                  この診断ではあなたの生年月日から、</br>
+                  気になる誰かの生年月日から！</br>
+                  性格、言われて嬉しい言葉、嫌な言葉を占います！</br>
+                  また、診断結果はお気に入りに保存できますので忘れてしまう心配も無用！</br></br>
+                  <ul>
+                    <li>ホーム：ホーム画面に飛びます。</li>
+                    <li>生年月日入力：生年月日から占いができます。</li>
+                    <li>お気に入り：お気に入り保存した占いを閲覧できます。</li>
+                    <li>このサイトについて：今押したボタン、操作説明。</li>
+                    <li>ログアウト：ログアウトをしてログイン画面に飛びます。</li>
+                  <ul>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-primary" data-dismiss="modal">閉じる</button>
+                </div>
+              </div>
+            </div>
+          </div>
+    
+        <li>
+          <ul class="navbar-nav px-3">
+            <li class="nav-item text-nowrap">
+              <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'navbar-link'  %> 
+            </li>
+          </ul>
         </li>
       </ul>
     </nav>
-
+  </div>
+    
     <div class="container-fluid">
       <div class="row">
         <%= yield %>


### PR DESCRIPTION
ウィンドウ幅が狭くなった際にメニューボタンを表示させて
メニューボタンをクリックすると、プルダウンが表示され、ヘッダーの項目が選択できるようにする。
スマートフォン等でも同様にメニューボタンの表示。
iPad等は大きい時のブラウザ同様通常表示される。